### PR TITLE
Add wait to effect tests

### DIFF
--- a/cypress/integration/codeName_Dolphin/Effects_spec.js
+++ b/cypress/integration/codeName_Dolphin/Effects_spec.js
@@ -1,8 +1,8 @@
 describe('Effects section', () => { 
   beforeEach(() => {
-    cy.visit('http://localhost:3000/')
-    cy.get('h1').click()
-    cy.viewport(1920, 975) 
+    cy.visit('/synth')
+    cy.viewport(1920, 975)
+    cy.wait(500)
   });
 
   it('should allow the user to adjust filter effects', () => {


### PR DESCRIPTION
# Description of Changes
Simply adding a wait to the cypress 'effects' tests so the site has time to render.
-

# Linked Issues
Closes #57 
Closes #56 
Closes #55 
-

###### _Make sure to tag people in the "Reviewers" section if needed_
